### PR TITLE
Standardize on std::byte for padding

### DIFF
--- a/AmethystAPI/src/minecraft/src-client/common/client/game/ClientInstance.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/game/ClientInstance.h
@@ -13,20 +13,20 @@ class ItemRenderer;
 class ClientInstance {
 private:
     uintptr_t** vtable;
-    bool padding0[192];
+    std::byte padding0[192];
 
 public:
     MinecraftGame* minecraftGame; // this + 200
     Minecraft* minecraft;         // this + 208
 
 private:
-    bool padding1[56];
+    std::byte padding1[56];
 
 public:
     ClientInputHandler* inputHandler; // this + 272
 
 private:
-    bool padding2[1088];
+    std::byte padding2[1088];
 
 public:
     ItemRenderer* itemRenderer; // this + 1368

--- a/AmethystAPI/src/minecraft/src-client/common/client/gui/ScreenView.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/gui/ScreenView.h
@@ -7,7 +7,7 @@ using UIRenderContext = MinecraftUIRenderContext;
 
 class ScreenView {
 public:
-    bool padding[72];
+    std::byte padding[72];
     VisualTree* visualTree; // this + 72
 
     // 48 8B C4 48 89 58 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 0F 29 70 ? 0F 29 78 ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 85 ? ? ? ? 4C 8B FA 48 89 54 24 ? 4C 8B E9 48 89 4C 24

--- a/AmethystAPI/src/minecraft/src-client/common/client/gui/controls/renderers/HoverRenderer.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/gui/controls/renderers/HoverRenderer.h
@@ -9,7 +9,7 @@ struct RectangleArea;
 
 class HoverRenderer {
 public:
-    char padding[56];
+    std::byte padding[56];
     std::string mFilteredContent; // this + 56
     glm::tvec2<float> mCursorPosition; // this + 88
     glm::tvec2<float> mOffset; // this + 96

--- a/AmethystAPI/src/minecraft/src-client/common/client/gui/gui/GuiData.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/gui/gui/GuiData.h
@@ -1,10 +1,12 @@
 #pragma once
 #include "minecraft/src/common/world/phys/Vec2.h"
 
+#include <cstddef>
+
 #pragma pack(push, 1)
 class GuiData {
 private:
-    char padding0[48];
+    std::byte padding0[48];
 
 public:
     Vec2 totalScreenSize;

--- a/AmethystAPI/src/minecraft/src-client/common/client/gui/gui/UIControl.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/gui/gui/UIControl.h
@@ -3,6 +3,6 @@
 
 class UIControl {
 public:
-  bool padding[24];
+  std::byte padding[24];
   std::string layerName; // this + 24
 };

--- a/AmethystAPI/src/minecraft/src-client/common/client/gui/gui/VisualTree.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/gui/gui/VisualTree.h
@@ -3,6 +3,6 @@
 
 class VisualTree {
 public:
-    bool padding[8];
+    std::byte padding[8];
     UIControl* mRootControlName; // this + 8
 };

--- a/AmethystAPI/src/minecraft/src-client/common/client/input/ClientInputHandler.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/input/ClientInputHandler.h
@@ -7,6 +7,6 @@ using IClientInstance = ClientInstance;
 class ClientInputHandler {
 public:
     ClientInstance* mClient;
-    bool padding[8];
+    std::byte padding[8];
     InputHandler* mInputHandler;
 };

--- a/AmethystAPI/src/minecraft/src-client/common/client/input/ClientInputMappingFactory.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/input/ClientInputMappingFactory.h
@@ -13,7 +13,7 @@ public:
 
 // Todo fill out this class if we want to support controller
 class GamePadRemappingLayout {
-    bool padding[0x58];
+    std::byte padding[0x58];
 };
 
 static_assert(sizeof(GamePadRemappingLayout) == 0x58);

--- a/AmethystAPI/src/minecraft/src-client/common/client/input/MinecraftInputHandler.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/input/MinecraftInputHandler.h
@@ -6,7 +6,7 @@
 class MinecraftInputHandler {
 public:
     uintptr_t** vtable;
-    bool padding[24];
+    std::byte padding[24];
     std::unique_ptr<InputHandler> mInputHandler;
 
 //hooks:

--- a/AmethystAPI/src/minecraft/src-client/common/client/options/Options.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/options/Options.h
@@ -6,7 +6,7 @@ class KeyboardRemappingLayout;
 
 class Options {
 public:
-    bool padding0[5984];
+    std::byte padding0[5984];
     // Found in Options::_readKeyboardMapping in call to RemappingLayout::setMapping
     std::vector<std::shared_ptr<KeyboardRemappingLayout>> mKeyboardRemappings;
 };

--- a/AmethystAPI/src/minecraft/src-client/common/client/renderer/BaseActorRenderContext.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/renderer/BaseActorRenderContext.h
@@ -12,9 +12,9 @@ class ItemRenderer;
 
 class BaseActorRenderContext {
 public:
-    bool padding[0x58];
+    std::byte padding[0x58];
     ItemRenderer* itemRenderer;
-    bool padding1[0x238];
+    std::byte padding1[0x238];
 
 public:
     BaseActorRenderContext(ScreenContext* screenContext, IClientInstance* clientInstance, IMinecraftGame* minecraftGame);

--- a/AmethystAPI/src/minecraft/src-client/common/client/renderer/screen/MinecraftUIRenderContext.h
+++ b/AmethystAPI/src/minecraft/src-client/common/client/renderer/screen/MinecraftUIRenderContext.h
@@ -61,7 +61,7 @@ public:
     IClientInstance* mClient;      // this + 8
     ScreenContext* mScreenContext; // this + 16
 private:
-    bool padding0[224];
+    std::byte padding0[224];
 
 public:
     void* mCurrentScene; // const UIScene*, this + 248

--- a/AmethystAPI/src/minecraft/src/common/world/actor/Actor.h
+++ b/AmethystAPI/src/minecraft/src/common/world/actor/Actor.h
@@ -13,11 +13,11 @@ private:
 public:
     EntityContext mEntityContext; // this + 8
 private:
-    bool padding[680];
+    std::byte padding[680];
 
 public:
     StateVectorComponent* mStateVectorComponent; // this + 712
-    bool padding1[504];
+    std::byte padding1[504];
 
 public:
     Vec3* getPosition();

--- a/AmethystAPI/src/minecraft/src/common/world/actor/Mob.h
+++ b/AmethystAPI/src/minecraft/src/common/world/actor/Mob.h
@@ -1,7 +1,7 @@
 #include "minecraft/src/common/world/actor/Actor.h"
 
 class Mob : public Actor {
-    bool _padding0[424];
+    std::byte _padding0[424];
 };
 
 static_assert(sizeof(Mob) == 1648);

--- a/AmethystAPI/src/minecraft/src/common/world/actor/player/Player.h
+++ b/AmethystAPI/src/minecraft/src/common/world/actor/player/Player.h
@@ -3,9 +3,9 @@
 
 class Player : public Mob {
 public:
-    bool __padding0[512];
+    std::byte __padding0[512];
     PlayerInventory* playerInventory; // this + 2024
-    bool __padding1[5416];
+    std::byte __padding1[5416];
 };
 
 static_assert(sizeof(Player) == 7584);

--- a/AmethystAPI/src/minecraft/src/common/world/item/Item.h
+++ b/AmethystAPI/src/minecraft/src/common/world/item/Item.h
@@ -55,18 +55,18 @@ namespace Puv {
 #pragma pack(push, 1)
 class Item {
 public:
-    bool padding0[104];
+    std::byte padding0[104];
     void* qword70; // this + 112
-    bool padding1[24];
+    std::byte padding1[24];
     void* qword90; // this + 144
-    bool padding2[10];
+    std::byte padding2[10];
     int16_t mId;        // this + 162
     int16_t mMaxDamage; // this + 164
-    bool padding3[2];
+    std::byte padding3[2];
     std::string* mItemName; // this + 168
-    bool padding4[72];
+    std::byte padding4[72];
     std::string mNamespace; // this + 248
-    bool padding5[320];
+    std::byte padding5[320];
 
 //virtuals:
 public:

--- a/AmethystAPI/src/minecraft/src/common/world/item/ItemStackBase.h
+++ b/AmethystAPI/src/minecraft/src/common/world/item/ItemStackBase.h
@@ -12,9 +12,9 @@ public:
     uintptr_t** vtable;
     WeakPtr<Item> mItem;    // this + 8
     CompoundTag* mUserData; // this + 16
-    bool padding0[10];
+    std::byte padding0[10];
     byte count; // this + 34;
-    bool padding1[120];
+    std::byte padding1[120];
 
 public:
     ItemStackBase() {};

--- a/AmethystAPI/src/minecraft/src/common/world/item/registry/ItemRegistry.h
+++ b/AmethystAPI/src/minecraft/src/common/world/item/registry/ItemRegistry.h
@@ -6,7 +6,7 @@
 
 class ItemRegistry {
 public:
-    char padding0[0x28]; 
+    std::byte padding0[0x28];
     std::unordered_map<int32_t, WeakPtr<Item>> mIdToItemMap; // this + 40
     std::unordered_map<HashedString, WeakPtr<Item>> mHashed;
 };


### PR DESCRIPTION
`sizeof(bool)` is implementation defined and is not guaranteed to be 1 byte. This PR standardizes on using `std::byte` for all byte padding, although `char`, `unsigned char`, or `uint8_t` are all viable options.