### PR TITLE
Fixed Version full version string

### DIFF
--- a/AmethystAPI/src/amethyst/runtime/minecraft/MinecraftPackageInfo.cpp
+++ b/AmethystAPI/src/amethyst/runtime/minecraft/MinecraftPackageInfo.cpp
@@ -18,12 +18,12 @@ Amethyst::MinecraftPackageInfo::MinecraftPackageInfo()
         package.Id().Version().Major,
         package.Id().Version().Minor,
         package.Id().Version().Build,
-        std::format(
+        fmt::format(
             "{}",
             package.Id().Version().Revision
             ),
         "",
-        std::format(
+        fmt::format(
             "{}.{}.{}.{}",
             package.Id().Version().Major,
             package.Id().Version().Minor,

--- a/AmethystAPI/src/amethyst/runtime/minecraft/MinecraftPackageInfo.cpp
+++ b/AmethystAPI/src/amethyst/runtime/minecraft/MinecraftPackageInfo.cpp
@@ -19,12 +19,12 @@ Amethyst::MinecraftPackageInfo::MinecraftPackageInfo()
         package.Id().Version().Minor,
         package.Id().Version().Build,
         std::format(
-            "%i",
+            "{}",
             package.Id().Version().Revision
             ),
         "",
         std::format(
-            "%i.%i.%i.%i",
+            "{}.{}.{}.{}",
             package.Id().Version().Major,
             package.Id().Version().Minor,
             package.Id().Version().Build,


### PR DESCRIPTION
I just saw while using it in AdvancedF3 that the version string was formatted using `%i` instead of `{}`, which caused the string to now be representing the verion