### PR TITLE
Remove DMs funny log

### DIFF
--- a/AmethystAPI/CMakeLists.txt
+++ b/AmethystAPI/CMakeLists.txt
@@ -13,7 +13,7 @@ file(GLOB_RECURSE AmethystAPI_All
     "src/*.c" 
     "src/*.asm"
     "src/*.hpp" 
-    "src/*.h" 
+    "src/*.h"
     minecraft/src/common/world/level/block/BlockLegacy.asm
     minecraft/src/common/world/item/BlockItem.asm
     minecraft/src/common/world/item/Item.asm 

--- a/AmethystRuntime/src/hooks/Hooks.cpp
+++ b/AmethystRuntime/src/hooks/Hooks.cpp
@@ -89,8 +89,6 @@ void* ClientInstance_ClientInstance(ClientInstance* self, uint64_t a2, uint64_t 
 void CreateModFunctionHooks() {
     HookManager* hookManager = AmethystRuntime::getHookManager();
 
-    Log::Info("jidwjekdf");
-
     hookManager->RegisterFunction<&ScreenView::setupAndRender>("48 8B C4 48 89 58 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 0F 29 70 ? 0F 29 78 ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 85 ? ? ? ? 4C 8B FA");
     hookManager->RegisterFunction<&Minecraft::update>("48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 55 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 0F 29 70 ? 0F 29 78 ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 85 ? ? ? ? 4C 8B E9 48");
     hookManager->RegisterFunction<&ClientInstance::onStartJoinGame>("40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ? 48 81 EC ? ? ? ? 45 8B F1");


### PR DESCRIPTION
It has come to our attention that `jidwjekdf` is not part of the english language nor part of any other meaningfull system of symbols used for communication by fellow humans. There for we hope to improve the enticing experience provided by the Amethyst runtime by removing this rather meaningless and uninformative text.

*sorry duck ):*
