### PR TITLE
Add CommandRequestPacket, add strings and UUID to BinaryStream

### DIFF
--- a/AmethystAPI/src/minecraft/src-deps/core/utility/BinaryStream.cpp
+++ b/AmethystAPI/src/minecraft/src-deps/core/utility/BinaryStream.cpp
@@ -15,6 +15,7 @@ Bedrock::Result<T> ReadOnlyBinaryStream::get()
 template Bedrock::Result<unsigned char> ReadOnlyBinaryStream::get<unsigned char>();
 template Bedrock::Result<uint64_t> ReadOnlyBinaryStream::get<uint64_t>();
 template Bedrock::Result<float> ReadOnlyBinaryStream::get<float>();
+template Bedrock::Result<bool> ReadOnlyBinaryStream::get<bool>();
 template Bedrock::Result<FacingID> ReadOnlyBinaryStream::get<FacingID>();
 
 Bedrock::Result<uint32_t> ReadOnlyBinaryStream::getUnsignedVarInt32()
@@ -45,6 +46,20 @@ Bedrock::Result<int32_t> ReadOnlyBinaryStream::getSignedVarInt32()
     return Bedrock::Result<int32_t>((value >> 1) ^ -static_cast<int32_t>(value & 1));
 }
 
+Bedrock::Result<std::string> ReadOnlyBinaryStream::getString()
+{
+    auto length = getUnsignedVarInt32();
+    if (!length) Assert("Issue with reading string length");
+
+    std::string value;
+    value.resize(length.value());
+
+    auto result = read(&value[0], length.value());
+    if (!result) Assert("Issue with reading string");
+
+    return Bedrock::Result<std::string>(value);
+}
+
 template <typename T>
 void BinaryStream::write(T in)
 {
@@ -57,6 +72,7 @@ void BinaryStream::write(T in)
 
 template void BinaryStream::write(unsigned char);
 template void BinaryStream::write(float);
+template void BinaryStream::write(bool);
 template void BinaryStream::write(uint64_t);
 template void BinaryStream::write(FacingID);
 
@@ -72,4 +88,9 @@ void BinaryStream::writeUnsignedVarInt32(uint32_t value)
 void BinaryStream::writeSignedVarInt32(int32_t value)
 {
     writeUnsignedVarInt32((value << 1) ^ (value >> 31));
+}
+
+void BinaryStream::writeString(std::string value) {
+    writeUnsignedVarInt32(value.size());
+    mBuffer += value;
 }

--- a/AmethystAPI/src/minecraft/src-deps/core/utility/BinaryStream.hpp
+++ b/AmethystAPI/src/minecraft/src-deps/core/utility/BinaryStream.hpp
@@ -20,10 +20,12 @@ public:
 
     Bedrock::Result<uint32_t> getUnsignedVarInt32();
     Bedrock::Result<int32_t> getSignedVarInt32();
+    Bedrock::Result<std::string> getString();
 };
 
 extern template Bedrock::Result<unsigned char> ReadOnlyBinaryStream::get<unsigned char>();
 extern template Bedrock::Result<float> ReadOnlyBinaryStream::get<float>();
+extern template Bedrock::Result<bool> ReadOnlyBinaryStream::get<bool>();
 
 class BinaryStream : public ReadOnlyBinaryStream {
 private:
@@ -38,7 +40,10 @@ public:
     //void writeUnsignedVarInt64(uint64_t value);
     void writeSignedVarInt32(int32_t value);
     //void writeSignedVarInt64(int64_t value);
+
+    void writeString(std::string value);
 };
 
 extern template void BinaryStream::write(unsigned char);
 extern template void BinaryStream::write(float);
+extern template void BinaryStream::write(bool);

--- a/AmethystAPI/src/minecraft/src-deps/core/utility/UUID.cpp
+++ b/AmethystAPI/src/minecraft/src-deps/core/utility/UUID.cpp
@@ -64,3 +64,17 @@ namespace mce {
 		return *this == EMPTY;
     }
 }
+
+template <>
+Bedrock::Result<mce::UUID> ReadOnlyBinaryStream::get<mce::UUID>() {
+    auto high = get<uint64_t>();
+    auto low = get<uint64_t>();
+
+	return Bedrock::Result<mce::UUID>(mce::UUID(high.value(), low.value()));
+};
+
+template <>
+void BinaryStream::write(mce::UUID in) {
+    write(in.getMostSignificantBits());
+    write(in.getLeastSignificantBits());
+}

--- a/AmethystAPI/src/minecraft/src-deps/core/utility/UUID.hpp
+++ b/AmethystAPI/src/minecraft/src-deps/core/utility/UUID.hpp
@@ -52,3 +52,12 @@ namespace mce {
         bool isEmpty() const;
     };
 }
+
+// BinaryStream
+#include "minecraft/src-deps/core/utility/BinaryStream.hpp"
+
+template <>
+Bedrock::Result<mce::UUID> ReadOnlyBinaryStream::get<mce::UUID>();
+
+template <>
+void BinaryStream::write(mce::UUID);

--- a/AmethystAPI/src/minecraft/src/common/network/packet/CommandRequestPacket.hpp
+++ b/AmethystAPI/src/minecraft/src/common/network/packet/CommandRequestPacket.hpp
@@ -1,0 +1,46 @@
+#include <minecraft/src/common/network/packet/Packet.hpp>
+#include <minecraft/src-deps/core/utility/UUID.hpp>
+
+struct CommandOriginData {
+public:
+	int			mType;
+	mce::UUID	mUuid;
+	std::string	mRequestId;
+	int64_t		mPlayerId;
+
+	CommandOriginData() : mType(0), mUuid(), mRequestId(""), mPlayerId(0) {};
+	CommandOriginData(struct CommandOriginData const& other) {
+		mType = other.mType;
+		mUuid = other.mUuid;
+		mRequestId = other.mRequestId;
+		mPlayerId = other.mPlayerId;
+	};
+	struct CommandOriginData& operator=(struct CommandOriginData const& rhs) {
+		CommandOriginData origin(rhs);
+		return origin;
+	};
+};
+
+class CommandRequestPacket : public Packet {
+public:
+	std::string			mCommand;
+	CommandOriginData	mOrigin;
+	bool				mIsInternal;
+	int					mVersion;
+
+public:
+	~CommandRequestPacket() {};
+	CommandRequestPacket() : mCommand(""), mOrigin(), mIsInternal(false), mVersion(0) {};
+
+	virtual MinecraftPacketIds getId() const override { return MinecraftPacketIds::CommandRequest; };
+	virtual std::string getName() const override { return "CommandRequestPacket"; };
+	virtual Bedrock::Result<void, std::error_code> _read(ReadOnlyBinaryStream& stream) override { Assert("Unimplemented"); };
+	virtual void write(BinaryStream& stream) override {
+		stream.writeString(mCommand);
+		stream.writeUnsignedVarInt32(mOrigin.mType);
+		stream.write(mOrigin.mUuid);
+		stream.writeString(mOrigin.mRequestId);
+		stream.write(mIsInternal);
+		stream.writeUnsignedVarInt32(mVersion);
+	};
+};


### PR DESCRIPTION
- Adds CommandRequestPacket class with write implementation
- Adds ReadOnlyBinaryStream::getString() and BinaryStream::writeString(std::string)
- Adds template for ReadOnlyBinaryStream::get<mce::UUID>() and BinaryStream::write(mce::UUID)

CommandOriginData will probably get moved somewhere else in the project as it isn't only used in packets