### PR TITLE
Move setSprinting function to its base class

### DIFF
--- a/AmethystAPI/src/minecraft/src-client/common/client/player/LocalPlayer.cpp
+++ b/AmethystAPI/src/minecraft/src-client/common/client/player/LocalPlayer.cpp
@@ -1,8 +1,0 @@
-#include "LocalPlayer.hpp"
-
-void LocalPlayer::setSprinting(bool isSprinting)
-{
-    using function = decltype(&LocalPlayer::setSprinting);
-    auto func = std::bit_cast<function>(this->vtable[153]);
-    return (this->*func)(isSprinting);
-}

--- a/AmethystAPI/src/minecraft/src-client/common/client/player/LocalPlayer.hpp
+++ b/AmethystAPI/src/minecraft/src-client/common/client/player/LocalPlayer.hpp
@@ -2,8 +2,4 @@
 #include "minecraft/src/common/world/actor/player/Player.hpp"
 #include <cstdint>
 
-class LocalPlayer : public Player {
-public:
-    // 1.21.0.3 - 48 89 5C 24 ? 57 48 83 EC ? 48 8B 01 0F B6 DA BA
-    void setSprinting(bool isSprinting);
-};
+class LocalPlayer : public Player {};

--- a/AmethystAPI/src/minecraft/src/common/world/actor/Mob.cpp
+++ b/AmethystAPI/src/minecraft/src/common/world/actor/Mob.cpp
@@ -1,0 +1,8 @@
+#include "Mob.hpp"
+
+void Mob::setSprinting(bool isSprinting)
+{
+    using function = decltype(&Mob::setSprinting);
+    auto func = std::bit_cast<function>(this->vtable[153]);
+    return (this->*func)(isSprinting);
+}

--- a/AmethystAPI/src/minecraft/src/common/world/actor/Mob.hpp
+++ b/AmethystAPI/src/minecraft/src/common/world/actor/Mob.hpp
@@ -3,6 +3,10 @@
 
 class Mob : public Actor {
     std::byte _padding0[424];
+
+public:
+    // 1.21.0.3 - 48 89 5C 24 ? 57 48 83 EC ? 48 8B 01 0F B6 DA BA
+    void setSprinting(bool isSprinting);
 };
 
 static_assert(sizeof(Mob) == 1648);


### PR DESCRIPTION
After a second look in IDA, I realized the vtables for LocalPlayer and Player have setSprinting labeled as Mob::setSprinting. I think the function signature was actually for Mob::setSprinting too, so I moved it to its most base class.