### PR TITLE
Fix include path for ContainerEnumName header

### DIFF
--- a/AmethystAPI/src/minecraft/src-client/common/client/gui/screens/controllers/ContainerScreenController.hpp
+++ b/AmethystAPI/src/minecraft/src-client/common/client/gui/screens/controllers/ContainerScreenController.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <unordered_map>
 #include <string>
-#include "minecraft/src-client/common/client/gui/screens/controllers/ContainerEnumName.hpp"
+#include "minecraft/src/common/world/containers/ContainerEnumName.hpp"
 
 #pragma pack(push, 1)
 class ContainerScreenController /** : ClientInstanceScreenController, MinecraftScreenController, ScreenController, IScreenController, std::enable_shared_from_this<MinecraftScreenController> **/ {


### PR DESCRIPTION
Updated the include directive to reference ContainerEnumName.hpp from the correct directory. This resolves potential build issues due to incorrect header file location.