### PR TITLE
Disable optimizations for debug and update Item constructor

### DIFF
--- a/AmethystAPI/src/mc/src/common/world/item/Item.hpp
+++ b/AmethystAPI/src/mc/src/common/world/item/Item.hpp
@@ -152,6 +152,9 @@ public:
 	/** @sig {E8 ? ? ? ? 88 9F ? ? ? ? 48 8D 05} */
     MC Item(const std::string& identifier, short numId);
 
+	/** @sig {E8 ? ? ? ? 88 9F ? ? ? ? 48 8D 05} */
+	MC static void $constructor(Item* self, const std::string& identifier, short numId);
+
     /** @vidx {000} */ MC virtual ~Item();
 	/** @vidx {001} */ MC virtual bool initServer(const Json::Value& config, const SemVersion& version, bool unk2, const Experiments& experiments);
 	/** @vidx {002} */ MC virtual void tearDown();


### PR DESCRIPTION
Disabled compiler optimizations for certain functions in Memory.cpp to facilitate easier debugging. Updated instruction operand checks to use operand_count_visible and relaxed some memory operand constraints. Added a static $constructor method to the Item class in Item.hpp.